### PR TITLE
Fix rubocop StringLiterals offense

### DIFF
--- a/cookbooks/apache/attributes/default.rb
+++ b/cookbooks/apache/attributes/default.rb
@@ -1,2 +1,2 @@
-default["apache"]["sites"]["clowns"] = { "port" => 80 }
-default["apache"]["sites"]["bears"] = { "port" => 81 }
+default['apache']['sites']['clowns'] = { 'port' => 80 }
+default['apache']['sites']['bears'] = { 'port' => 81 }

--- a/cookbooks/apache/recipes/default.rb
+++ b/cookbooks/apache/recipes/default.rb
@@ -7,45 +7,45 @@
 # All rights reserved - Do Not Redistribute
 #
 
-package "httpd" do
+package 'httpd' do
   action :install
 end
 
-service "httpd" do
+service 'httpd' do
   action [ :enable, :start ]
 end
 
-execute "mv /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/welcome.conf.disabled" do
+execute 'mv /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/welcome.conf.disabled' do
   only_if do
-    File.exist?("/etc/httpd/conf.d/welcome.conf")
+    File.exist?('/etc/httpd/conf.d/welcome.conf')
   end
-  notifies :restart, "service[httpd]"
+  notifies :restart, 'service[httpd]'
 end
 
-node["apache"]["sites"].each do |site_name, site_data|
+node['apache']['sites'].each do |site_name, site_data|
   document_root = "/srv/apache/#{site_name}"
 
   template "/etc/httpd/conf.d/#{site_name}.conf" do
-    source "custom.erb"
-    mode "0644"
+    source 'custom.erb'
+    mode '0644'
     variables(
       :document_root => document_root,
-      :port => site_data["port"]
+      :port => site_data['port']
     )
-    notifies :restart, "service[httpd]"
+    notifies :restart, 'service[httpd]'
   end
 
   directory document_root do
-    mode "0755"
+    mode '0755'
     recursive true
   end
 
   template "#{document_root}/index.html" do
-    source "index.html.erb"
-    mode "0644"
+    source 'index.html.erb'
+    mode '0644'
     variables(
       :site_name => site_name,
-      :port => site_data["port"]
+      :port => site_data['port']
     )
   end
 end

--- a/cookbooks/apache/recipes/user00_index.rb
+++ b/cookbooks/apache/recipes/user00_index.rb
@@ -1,4 +1,4 @@
-cookbook_file "/var/www/html/user00_index.html" do
-  source "user00_index.html"
-  mode "0644"
+cookbook_file '/var/www/html/user00_index.html' do
+  source 'user00_index.html'
+  mode '0644'
 end

--- a/cookbooks/motd/attributes/default.rb
+++ b/cookbooks/motd/attributes/default.rb
@@ -1,1 +1,1 @@
-default["motd"]["company"] = "Chef"
+default['motd']['company'] = 'Chef'

--- a/cookbooks/motd/metadata.rb
+++ b/cookbooks/motd/metadata.rb
@@ -7,4 +7,4 @@ description      'Installs/Configures motd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-depends "pci"
+depends 'pci'

--- a/cookbooks/motd/recipes/default.rb
+++ b/cookbooks/motd/recipes/default.rb
@@ -6,7 +6,7 @@
 #
 # All rights reserved - Do Not Redistribute
 #
-template "/etc/motd" do
-   source "motd.erb"
-   mode "0644"
+template '/etc/motd' do
+   source 'motd.erb'
+   mode '0644'
  end

--- a/cookbooks/rubocop-todo.yml
+++ b/cookbooks/rubocop-todo.yml
@@ -18,9 +18,3 @@ FinalNewline:
 # Cop supports --auto-correct.
 SpaceInsideBrackets:
   Enabled: false
-
-# Offense count: 33
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-StringLiterals:
-  Enabled: false


### PR DESCRIPTION
- Remove the StringLiterals stanza from the rubocop-todo.yml
- run `rubocop cookbooks -a`
